### PR TITLE
Implement Exists() method for UnityAudioProtocol

### DIFF
--- a/Runtime/FilesManagement/Protocols/UnityAudioProtocol.cs
+++ b/Runtime/FilesManagement/Protocols/UnityAudioProtocol.cs
@@ -26,7 +26,9 @@ namespace Padoru.Core.Files
 		
 		public Task<bool> Exists(string uri, CancellationToken token = default)
 		{
-			throw new System.NotImplementedException();
+			var requestUri = GetRequestUri(uri);
+
+			return Task.FromResult(File.Exists(requestUri));
 		}
 
 		public async Task<object> Read<T>(string uri, string version = null, CancellationToken token = default)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.padoru.core-lib",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "displayName": "Padoru Core",
   "description": "A core library to develop games in Unity",
   "unity": "2020.3",


### PR DESCRIPTION
This is causing audio files to not be loaded otherwise. See Slack thread here: https://seriesai.slack.com/archives/C04QCDML1AR/p1714781698783069

## Testing
Ran the game in editor.

Before my change, music wasn't playing.
After my change, music is playing again.