### PR TITLE
[Bugfix] Correctly search for the audio file

### DIFF
--- a/Runtime/FilesManagement/Protocols/UnityAudioProtocol.cs
+++ b/Runtime/FilesManagement/Protocols/UnityAudioProtocol.cs
@@ -26,9 +26,9 @@ namespace Padoru.Core.Files
 		
 		public Task<bool> Exists(string uri, CancellationToken token = default)
 		{
-			var requestUri = GetRequestUri(uri);
+			var filePath = GetFullPath(uri);
 
-			return Task.FromResult(File.Exists(requestUri));
+			return Task.FromResult(File.Exists(filePath));
 		}
 
 		public async Task<object> Read<T>(string uri, string version = null, CancellationToken token = default)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.padoru.core-lib",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "displayName": "Padoru Core",
   "description": "A core library to develop games in Unity",
   "unity": "2020.3",


### PR DESCRIPTION
This was incorrectly prepending `file://` and then further prepending the path to that.

More details in slack thread.

https://seriesai.slack.com/archives/C04QCDML1AR/p1715029224068589?thread_ts=1714781698.783069&cid=C04QCDML1AR

## Testing

Ran the game before my change, verified that audio files were getting redownloaded.
Ran the game in editor after my change, verified from logs that audio files are no longer getting redownloaded.

Ran the game in WebGL, it didn't work (due to https://github.com/series-ai/unity-package-core/pull/23).