### PR TITLE
Bug/xo 4473 allow for async shutdown

### DIFF
--- a/Runtime/Initialization/IShutdownalbeAsync.cs
+++ b/Runtime/Initialization/IShutdownalbeAsync.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Padoru.Core
+{
+    public interface IShutdownableAsync
+    {
+        Task Shutdown(CancellationToken token);
+    }
+}

--- a/Runtime/Initialization/IShutdownalbeAsync.cs.meta
+++ b/Runtime/Initialization/IShutdownalbeAsync.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 77b9a7c4276f64d299c792d03c68a243
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/Initialization/CotextTests.cs
+++ b/Tests/Editor/Initialization/CotextTests.cs
@@ -43,26 +43,22 @@ namespace Padoru.Core.Tests
             Assert.Throws<AggregateException>(() => Task.Run(context.Init).Wait());
         }
 
-        [UnityTest]
-        public IEnumerator ShutdownContext_WhenContextInitialized_ShouldNotBeInitialized()
+        [Test]
+        public async void ShutdownContext_WhenContextInitialized_ShouldNotBeInitialized()
         {
-            yield return null;
-
             var context = go.AddComponent<Context>();
-            context.Init();
+            await Task.Run(context.Init);
 
-            Assert.DoesNotThrow(context.Shutdown);
+            Assert.DoesNotThrow(() => Task.Run(context.Shutdown).Wait());
             Assert.IsFalse(context.IsInitialized);
         }
 
-        [UnityTest]
-        public IEnumerator ShutdownContext_WhenContextNotInitialized_ShouldThrowException()
+        [Test]
+        public async void ShutdownContext_WhenContextNotInitialized_ShouldThrowException()
         {
-            yield return null;
-
             var context = go.AddComponent<Context>();
 
-            Assert.Throws<Exception>(context.Shutdown);
+            Assert.Throws<AggregateException>(() => Task.Run(context.Shutdown).Wait());
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.padoru.core-lib",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "displayName": "Padoru Core",
   "description": "A core library to develop games in Unity",
   "unity": "2020.3",


### PR DESCRIPTION
Summary
This adds a way to let initializers have an async shut down and fixes a possible bug with our shut down logic. It shuts down things in reverse order of initializing. That way if you depend on the file manager, for example, it still exists when a component that depends on it tries to access it during it's own shut down.

This is to support the new embedded assets tool changes.