### PR TITLE
File System Refactor

### DIFF
--- a/Runtime/FilesManagement/File.cs
+++ b/Runtime/FilesManagement/File.cs
@@ -4,11 +4,13 @@
     {
         public readonly string Uri;
         public readonly T Data;
+        public readonly byte[] Bytes;
 
-        public File(string uri, T data)
+        public File(string uri, T data, byte[] bytes)
         {
             Uri = uri;
             Data = data;
+            Bytes = bytes;
         }
     }
 }

--- a/Runtime/FilesManagement/FileManager.cs
+++ b/Runtime/FilesManagement/FileManager.cs
@@ -72,9 +72,7 @@ namespace Padoru.Core.Files
 
         public async Task<File<T>> Read<T>(string uri, CancellationToken cancellationToken, string version = null)
         {
-            var value = await GetProtocol(uri).Read<T>(uri, cancellationToken, version);
-
-            return new File<T>(uri, (T)value);
+            return await GetProtocol(uri).Read<T>(uri, cancellationToken, version);
         }
 
         public async Task<File<T>> Write<T>(string uri, T value, CancellationToken cancellationToken)

--- a/Runtime/FilesManagement/FileSystems/AndroidFileSystem.cs
+++ b/Runtime/FilesManagement/FileSystems/AndroidFileSystem.cs
@@ -46,7 +46,7 @@ namespace Padoru.Core.Files
             return uwr.result == UnityWebRequest.Result.Success;
         }
 
-        public async Task<File<byte[]>> Read(string uri, CancellationToken cancellationToken, string version = null)
+        public async Task<byte[]> Read(string uri, CancellationToken cancellationToken, string version = null)
         {
             var requestUri = GetRequestUri(uri);
 			
@@ -67,18 +67,18 @@ namespace Padoru.Core.Files
             }
             
             var manifestData = uwr.downloadHandler.data;
-            return new File<byte[]>(uri, manifestData);
+            return manifestData;
         }
 
-        public async Task Write(File<byte[]> file, CancellationToken cancellationToken)
+        public async Task Write(string uri, byte[] bytes, CancellationToken cancellationToken)
         {
-            var path = GetFullPath(file.Uri);
+            var path = GetFullPath(uri);
 
             var directory = Path.GetDirectoryName(path) ?? ".";
             
             Directory.CreateDirectory(directory);
 
-            await File.WriteAllBytesAsync(path, file.Data, cancellationToken);
+            await File.WriteAllBytesAsync(path, bytes, cancellationToken);
         }
 
         public Task Delete(string uri, CancellationToken cancellationToken)

--- a/Runtime/FilesManagement/FileSystems/HttpsFileSystem.cs
+++ b/Runtime/FilesManagement/FileSystems/HttpsFileSystem.cs
@@ -29,7 +29,7 @@ namespace Padoru.Core.Files
             return response.IsSuccessStatusCode;
         }
 
-        public async Task<File<byte[]>> Read(string uri, CancellationToken cancellationToken, string version = null)
+        public async Task<byte[]> Read(string uri, CancellationToken cancellationToken, string version = null)
         {
             var path = GetFullPath(uri);
 
@@ -63,14 +63,13 @@ namespace Padoru.Core.Files
             }
             
             var data = await response.Content.ReadAsByteArrayAsync();
-                
-            return new File<byte[]>(uri, data);
+            return data;
         }
 
-        public async Task Write(File<byte[]> file, CancellationToken cancellationToken)
+        public async Task Write(string uri, byte[] bytes, CancellationToken cancellationToken)
         {
-            var path = GetFullPath(file.Uri);
-            var content = new ByteArrayContent(file.Data);
+            var path = GetFullPath(uri);
+            var content = new ByteArrayContent(bytes);
             var response = await client.PostAsync(path, content, cancellationToken);
             
             if (!response.IsSuccessStatusCode)

--- a/Runtime/FilesManagement/FileSystems/LocalFileSystem.cs
+++ b/Runtime/FilesManagement/FileSystems/LocalFileSystem.cs
@@ -26,7 +26,7 @@ namespace Padoru.Core.Files
             return await Task.FromResult(File.Exists(path));
         }
 
-        public async Task<File<byte[]>> Read(string uri, CancellationToken cancellationToken, string version = null)
+        public async Task<byte[]> Read(string uri, CancellationToken cancellationToken, string version = null)
         {
             var path = GetFullPath(uri);
 
@@ -50,13 +50,13 @@ namespace Padoru.Core.Files
                     offset += bytesRead;
                 }
 
-                return new File<byte[]>(uri, bytes);
+                return bytes;
             }
         }
 
-        public async Task Write(File<byte[]> file, CancellationToken cancellationToken)
+        public async Task Write(string uri, byte[] bytes, CancellationToken cancellationToken)
         {
-            var path = GetFullPath(file.Uri);
+            var path = GetFullPath(uri);
 
             var directory = Path.GetDirectoryName(path) ?? ".";
             
@@ -64,7 +64,7 @@ namespace Padoru.Core.Files
             
             using (FileStream fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true))
             {
-                await fs.WriteAsync(file.Data, 0, file.Data.Length, cancellationToken);
+                await fs.WriteAsync(bytes, 0, bytes.Length, cancellationToken);
             }
         }
 

--- a/Runtime/FilesManagement/FileSystems/MemoryFileSystem.cs
+++ b/Runtime/FilesManagement/FileSystems/MemoryFileSystem.cs
@@ -7,14 +7,14 @@ namespace Padoru.Core.Files
 {
     public class MemoryFileSystem : IFileSystem
     {
-        private readonly Dictionary<string, File<byte[]>> files = new();
+        private readonly Dictionary<string, byte[]> files = new();
 
         public async Task<bool> Exists(string uri, CancellationToken cancellationToken)
         {
             return await Task.FromResult(files.ContainsKey(uri));
         }
 
-        public async Task<File<byte[]>> Read(string uri, CancellationToken cancellationToken, string version = null)
+        public async Task<byte[]> Read(string uri, CancellationToken cancellationToken, string version = null)
         {
             if (files.TryGetValue(uri, out var file))
             {
@@ -24,9 +24,9 @@ namespace Padoru.Core.Files
             throw new FileNotFoundException($"Could not find file. Uri {uri}");
         }
 
-        public async Task Write(File<byte[]> file, CancellationToken cancellationToken)
+        public async Task Write(string uri, byte[] bytes, CancellationToken cancellationToken)
         {
-            files[file.Uri] = file;
+            files[uri] = bytes;
 
             await Task.CompletedTask;
         }

--- a/Runtime/FilesManagement/FileSystems/WebGLFileSystem.cs
+++ b/Runtime/FilesManagement/FileSystems/WebGLFileSystem.cs
@@ -15,7 +15,7 @@ namespace Padoru.Core.Files
         private readonly string webRequestProtocol;
         private readonly Regex protocolRegex;
         
-        private readonly Dictionary<string, File<byte[]>> files = new();
+        private readonly Dictionary<string, byte[]> files = new();
 
         public WebGLFileSystem(string webRequestProtocol)
         {
@@ -55,7 +55,7 @@ namespace Padoru.Core.Files
             return uwr.result == UnityWebRequest.Result.Success;
         }
 
-        public async Task<File<byte[]>> Read(string uri, CancellationToken cancellationToken, string version = null)
+        public async Task<byte[]> Read(string uri, CancellationToken cancellationToken, string version = null)
         {
             if (files.ContainsKey(uri))
             {
@@ -80,15 +80,15 @@ namespace Padoru.Core.Files
             if (uwr.result == UnityWebRequest.Result.Success) 
             {
                 var manifestData = uwr.downloadHandler.data;
-                return new File<byte[]>(uri, manifestData);
+                return manifestData;
             }
             
             throw new FileNotFoundException($"Could not read file at path '{requestUri}'. Error: {uwr.error}");
         }
 
-        public async Task Write(File<byte[]> file, CancellationToken cancellationToken)
+        public async Task Write(string uri, byte[] bytes, CancellationToken cancellationToken)
         {
-            files[file.Uri] = file;
+            files[uri] = bytes;
 
             await Task.CompletedTask;
         }

--- a/Runtime/FilesManagement/IFileSystem.cs
+++ b/Runtime/FilesManagement/IFileSystem.cs
@@ -7,9 +7,9 @@ namespace Padoru.Core.Files
     {
         Task<bool> Exists(string uri, CancellationToken cancellationToken);
 
-        Task<File<byte[]>> Read(string uri, CancellationToken cancellationToken, string version = null);
+        Task<byte[]> Read(string uri, CancellationToken cancellationToken, string version = null);
 
-        Task Write(File<byte[]> file, CancellationToken cancellationToken);
+        Task Write(string uri, byte[] bytes, CancellationToken cancellationToken);
 
         Task Delete(string uri, CancellationToken cancellationToken);
     }

--- a/Runtime/FilesManagement/IProtocol.cs
+++ b/Runtime/FilesManagement/IProtocol.cs
@@ -7,7 +7,7 @@ namespace Padoru.Core.Files
 	{
 		Task<bool> Exists(string uri, CancellationToken cancellationToken);
 
-		Task<object> Read<T>(string uri, CancellationToken cancellationToken, string version = null);
+		Task<File<T>> Read<T>(string uri, CancellationToken cancellationToken, string version = null);
 
 		Task<File<T>> Write<T>(string uri, T value, CancellationToken cancellationToken);
 

--- a/Runtime/FilesManagement/Protocols/UnityAudioProtocol.cs
+++ b/Runtime/FilesManagement/Protocols/UnityAudioProtocol.cs
@@ -41,7 +41,7 @@ namespace Padoru.Core.Files
 			return Task.FromResult(File.Exists(filePath));
 		}
 
-		public async Task<object> Read<T>(string uri, CancellationToken cancellationToken, string version = null)
+		public async Task<File<T>> Read<T>(string uri, CancellationToken cancellationToken, string version = null)
 		{
 			var requestUri = GetRequestUri(uri);
         
@@ -53,9 +53,10 @@ namespace Padoru.Core.Files
 			using (UnityWebRequest wr = new UnityWebRequest(requestUri, "GET", dh, null)) 
 			{
 				await wr.SendWebRequest().AsTask(coroutineProxy, cancellationToken);
-				if (wr.responseCode == 200) 
+				if (wr.responseCode == 200)
 				{
-					return dh.audioClip;
+					object audioClip = dh.audioClip;
+					return new File<T>(uri, (T) audioClip, dh.data);
 				}
 				
 				Debug.LogError($"Download failed. Uri {requestUri} Response {wr.responseCode}. Error: {wr.error}", DebugChannels.FILES);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.padoru.core-lib",
-  "version": "1.19.7",
+  "version": "1.19.8",
   "displayName": "Padoru Core",
   "description": "A core library to develop games in Unity",
   "unity": "2020.3",


### PR DESCRIPTION
#### Description
This is part of a general Cadmus refactor that will improve loading times. I refactored the FileSystem logic to obtain the bytes of the files. This is being used by the AssetManager to copy files from StreamingAssets to PersistentData using the bytes.
I also added a new code to the Bootstrapper to wait to get AssetPacks (this is for Android + SplitApplicationBinary)

Related PRs:
https://github.com/series-ai/unity-package-core/pull/48
https://github.com/series-ai/cadmus/pull/1504
https://github.com/series-ai/unity-package-avatar-2d/pull/388

